### PR TITLE
Add pytest

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,4 +3,4 @@ dependencies:
     - sh setup.sh
 test:
   override:
-    - python polyline_test.py
+    - python test.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 polyline==1.3
+pytest

--- a/test.py
+++ b/test.py
@@ -1,0 +1,36 @@
+import itertools
+import json
+import os
+import subprocess
+
+import pytest
+
+libraries = [
+    "./mapbox-polyline",
+    "./jieter-leaflet-encoded",
+    "./joshuaclayton-polylines",
+    "./frederickjansen-polyline"
+]
+
+fixtures = json.load(open('./fixtures/canon.json'))
+
+testdata = list(itertools.product(libraries, fixtures))
+
+@pytest.mark.parametrize("library, fixture", testdata)
+def test_encode(library, fixture):
+    result = subprocess.check_output(
+        [os.path.join(library, "encode"), json.dumps(fixture["input"])])
+
+    assert fixture["output"] == result
+
+
+@pytest.mark.parametrize("library, fixture", testdata)
+def test_decode(library, fixture):
+    result = subprocess.check_output(
+        [os.path.join(library, "decode"), fixture["output"]])
+
+    assert fixture["input"] == json.loads(result)
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
This PR replaces the `unitest` example with [`pytest`](https://pytest.org/latest/index.html). The main benefit here is the `parameterize` decorator which takes a python list of test fixtures and runs them as independent tests.
